### PR TITLE
Wrapped page content conversion migration in transaction

### DIFF
--- a/database/migrations/2022_01_12_103224_update_information_pages_convert_to_pages.php
+++ b/database/migrations/2022_01_12_103224_update_information_pages_convert_to_pages.php
@@ -14,31 +14,34 @@ class UpdateInformationPagesConvertToPages extends Migration
      */
     public function up()
     {
-        $content = DB::table('information_pages')->pluck('content', 'id');
+        DB::transaction(function () {
 
-        Schema::rename('information_pages', 'pages');
+            $content = DB::table('information_pages')->pluck('content', 'id');
 
-        Schema::table('pages', function (Blueprint $table) {
-            $table->dropColumn('content');
+            Schema::rename('information_pages', 'pages');
+
+            Schema::table('pages', function (Blueprint $table) {
+                $table->dropColumn('content');
+            });
+
+            Schema::table('pages', function (Blueprint $table) {
+                $table->json('content');
+            });
+
+            foreach ($content as $id => $copy) {
+                DB::table('pages')
+                    ->where('id', $id)
+                    ->update([
+                        'content' => json_encode([
+                            'introduction' => [
+                                'label' => 'Page content',
+                                'hint' => 'This is the largest content of the page. Use formatting to improve readability and impact.',
+                                'copy' => [$copy],
+                            ],
+                        ]),
+                    ]);
+            }
         });
-
-        Schema::table('pages', function (Blueprint $table) {
-            $table->json('content');
-        });
-
-        foreach ($content as $id => $copy) {
-            DB::table('pages')
-                ->where('id', $id)
-                ->update([
-                    'content' => json_encode([
-                        'introduction' => [
-                            'label' => 'Page content',
-                            'hint' => 'This is the largest content of the page. Use formatting to improve readability and impact.',
-                            'copy' => [$copy],
-                        ],
-                    ]),
-                ]);
-        }
     }
 
     /**
@@ -46,24 +49,26 @@ class UpdateInformationPagesConvertToPages extends Migration
      */
     public function down()
     {
-        $content = DB::table('pages')->pluck('content', 'id');
+        DB::transaction(function () {
+            $content = DB::table('pages')->pluck('content', 'id')->all();
 
-        Schema::rename('pages', 'information_pages');
+            Schema::rename('pages', 'information_pages');
 
-        Schema::table('information_pages', function (Blueprint $table) {
-            $table->dropColumn('content');
+            Schema::table('information_pages', function (Blueprint $table) {
+                $table->dropColumn('content');
+            });
+
+            Schema::table('information_pages', function (Blueprint $table) {
+                $table->text('content');
+            });
+
+            foreach ($content as $id => $contentJson) {
+                $copy = json_decode($contentJson);
+                $copy = $copy['content']['introduction']['copy'][0] ?? null;
+                DB::table('pages')
+                    ->where('id', $id)
+                    ->update($copy);
+            }
         });
-
-        Schema::table('information_pages', function (Blueprint $table) {
-            $table->text('content');
-        });
-
-        foreach ($content as $id => $contentJson) {
-            $copy = json_decode($contentJson);
-            $copy = $copy['content']['introduction']['copy'][0] ?? null;
-            DB::table('pages')
-                ->where('id', $id)
-                ->update($copy);
-        }
     }
 }

--- a/database/migrations/2022_01_12_103224_update_information_pages_convert_to_pages.php
+++ b/database/migrations/2022_01_12_103224_update_information_pages_convert_to_pages.php
@@ -15,7 +15,6 @@ class UpdateInformationPagesConvertToPages extends Migration
     public function up()
     {
         DB::transaction(function () {
-
             $content = DB::table('information_pages')->pluck('content', 'id');
 
             Schema::rename('information_pages', 'pages');


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/1496/allow-information-pages-to-be-assigned-to-landing-pages

Small fix to get migration to work

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist
NA

### Notes

NA
